### PR TITLE
Increase lifetime from 2h to 4h for compatibility with Aura.Auth

### DIFF
--- a/src/Factory/AuraSessionFactory.php
+++ b/src/Factory/AuraSessionFactory.php
@@ -12,7 +12,7 @@ class AuraSessionFactory
      */
     protected $options = [
         'name'     => 'PHPSESSID',
-        'lifetime' => 7200,
+        'lifetime' => 14400,
         'path'     => null,
         'domain'   => null,
         'secure'   => false,

--- a/tests/Factory/AuraSessionFactoryTest.php
+++ b/tests/Factory/AuraSessionFactoryTest.php
@@ -33,7 +33,7 @@ class AuraSessionFactoryTest extends \PHPUnit_Framework_TestCase
         $session = $factory->__invoke($this->container->reveal());
 
         $this->assertSame([
-            'lifetime' => 7200,
+            'lifetime' => 14400,
             'path'     => null,
             'domain'   => null,
             'secure'   => false,


### PR DESCRIPTION
The `lifetime` value interferes with the default value in [`Aura\Auth\Session\Timer`](https://github.com/auraphp/Aura.Auth/blob/2.x/src/Session/Timer.php#L74). It will throw an [exception](https://github.com/auraphp/Aura.Auth/blob/2.x/src/Session/Timer.php#L131).